### PR TITLE
Fix mockup terminology

### DIFF
--- a/rinnova/docs/SoftwareArchitecture.md
+++ b/rinnova/docs/SoftwareArchitecture.md
@@ -1,4 +1,4 @@
-# Rinnova · Frontend Mockup MoCap
+# Rinnova · Frontend Mockup
 
 Questa pagina descrive l'architettura della prima bozza frontend di **Rinnova**, sviluppata come mock dimostrativo per illustrare al cliente il funzionamento del servizio.
 

--- a/rinnova/index.html
+++ b/rinnova/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MoCap Rinnova – Valuta e racconta i tuoi oggetti</title>
+    <title>Rinnova Mockup – Valuta e racconta i tuoi oggetti</title>
     <!--
         Pagina principale del mockup frontend.
         Strutturata per essere facilmente integrabile con backend/API futuri.
@@ -19,7 +19,7 @@
         <div class="hero__overlay"></div>
         <div class="hero__content container">
             <div>
-                <p class="hero__eyebrow">Demo MoCap · Rinnova</p>
+                <p class="hero__eyebrow">Demo Mockup · Rinnova</p>
                 <h1>Trasforma una foto in un annuncio pronto per la vendita</h1>
                 <p class="hero__subtitle">
                     Carica l'oggetto, aggiungi qualche dettaglio facoltativo e lascia che l'IA faccia il resto:
@@ -129,7 +129,7 @@
 
     <footer class="footer">
         <div class="container footer__content">
-            <p><strong>Rinnova · MoCap</strong> — mockup frontend generato da AI per la fase di concept.</p>
+            <p><strong>Rinnova · Mockup</strong> — mockup frontend generato da AI per la fase di concept.</p>
             <p class="footer__links">
                 <a href="docs/SoftwareArchitecture.md">Documentazione</a>
                 <span aria-hidden="true">·</span>


### PR DESCRIPTION
## Summary
- replace the erroneous "MoCap" wording with the intended "Mockup" in the frontend documentation
- update the landing page metadata and footer copy to reflect the correct mockup naming

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5881910bc832abc096c1274a1f85d