### PR TITLE
Add static e-commerce mockup and navigation

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -54,12 +54,62 @@ img {
     margin: 0 auto;
 }
 
+.site-header {
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.site-header__content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 0;
+    gap: 24px;
+}
+
+.site-header__brand {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--color-primary-dark);
+    text-decoration: none;
+}
+
+.site-header__nav {
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
+    font-weight: 500;
+}
+
+.site-header__nav a {
+    text-decoration: none;
+    color: var(--color-text);
+    padding: 6px 12px;
+    border-radius: var(--radius-small);
+    transition: background var(--transition), color var(--transition);
+}
+
+.site-header__nav a:hover,
+.site-header__nav a:focus,
+.site-header__nav a[aria-current="page"] {
+    background: rgba(47, 139, 253, 0.12);
+    color: var(--color-primary-dark);
+}
+
 .hero {
     position: relative;
     overflow: hidden;
     padding: 100px 0 120px;
     background: linear-gradient(135deg, rgba(47, 139, 253, 0.95), rgba(0, 198, 174, 0.85));
     color: #fff;
+}
+
+.hero--subpage {
+    padding: 80px 0 100px;
 }
 
 .hero__overlay {
@@ -137,6 +187,7 @@ img {
 
 .section {
     padding: 80px 0;
+    scroll-margin-top: 120px;
 }
 
 .section--alt {
@@ -152,11 +203,49 @@ img {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.grid--two-columns {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
 .panel {
     background: var(--color-surface);
     border-radius: var(--radius-large);
     padding: 40px;
     box-shadow: var(--shadow-soft);
+}
+
+.panel--info {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.panel--filters {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.panel--mini {
+    background: rgba(47, 139, 253, 0.08);
+    border-radius: var(--radius-medium);
+    padding: 20px;
+    box-shadow: none;
+}
+
+.panel--store-preview {
+    background: #0f172a;
+    color: rgba(255, 255, 255, 0.92);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.panel__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
 }
 
 .panel--status {
@@ -363,6 +452,16 @@ textarea:focus {
     margin-bottom: 6px;
 }
 
+.store-preview__header {
+    display: flex;
+    gap: 8px;
+}
+
+.store-preview__body {
+    display: grid;
+    gap: 16px;
+}
+
 .result-card {
     background: linear-gradient(135deg, rgba(47, 139, 253, 0.08), rgba(0, 198, 174, 0.14));
     border-radius: var(--radius-large);
@@ -397,6 +496,146 @@ textarea:focus {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
+}
+
+.checklist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.checklist li {
+    position: relative;
+    padding-left: 26px;
+    line-height: 1.5;
+}
+
+.checklist li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 6px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(47, 139, 253, 0.9), rgba(0, 198, 174, 0.9));
+    mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="white" d="M6.173 13.233a1 1 0 0 1-1.414 0l-3.64-3.64a1 1 0 1 1 1.414-1.414L6 10.646l6.467-6.467a1 1 0 1 1 1.414 1.414z"/></svg>') center/12px 12px no-repeat;
+}
+
+.product-card {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: var(--radius-medium);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: var(--shadow-soft);
+    border: 1px solid rgba(28, 77, 216, 0.08);
+}
+
+.panel--store-preview .product-card {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: none;
+}
+
+.product-card__category {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+}
+
+.panel--store-preview .product-card__category,
+.panel--store-preview .product-card__price,
+.panel--store-preview .product-card__description {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.product-card__price {
+    font-weight: 600;
+    font-size: 1.2rem;
+    color: var(--color-primary-dark);
+}
+
+.product-card__description {
+    line-height: 1.5;
+    color: var(--color-text);
+}
+
+.product-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.product-card__tags span {
+    background: rgba(47, 139, 253, 0.12);
+    color: var(--color-primary-dark);
+    border-radius: var(--radius-small);
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.product-card__meta {
+    margin: 0;
+    padding-left: 18px;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.product-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.catalogue {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.catalogue__summary {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.product-card.is-hidden {
+    display: none;
+}
+
+.filter-buttons {
+    display: grid;
+    gap: 10px;
+}
+
+.filter-button {
+    border: 1px solid rgba(28, 77, 216, 0.18);
+    background: #fff;
+    border-radius: var(--radius-medium);
+    padding: 12px 16px;
+    font-weight: 600;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.filter-button:hover,
+.filter-button:focus {
+    border-color: rgba(47, 139, 253, 0.5);
+    color: var(--color-primary-dark);
+}
+
+.filter-button.is-active {
+    background: linear-gradient(135deg, rgba(47, 139, 253, 0.15), rgba(0, 198, 174, 0.12));
+    border-color: rgba(47, 139, 253, 0.6);
+    color: var(--color-primary-dark);
 }
 
 .feature {
@@ -439,6 +678,10 @@ textarea:focus {
         padding: 80px 0 100px;
     }
 
+    .site-header__content {
+        padding: 14px 0;
+    }
+
     .panel {
         padding: 32px;
     }
@@ -446,6 +689,10 @@ textarea:focus {
     .form-actions {
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .site-header__nav {
+        justify-content: center;
     }
 }
 
@@ -460,5 +707,9 @@ textarea:focus {
 
     .panel {
         padding: 24px;
+    }
+
+    .site-header__nav {
+        gap: 12px;
     }
 }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -194,7 +194,7 @@ function handleDownload() {
  */
 function handleShare() {
     const marketplaces = ["eBay", "Vinted", "Subito"];
-    const message = `Mock inviato a: ${marketplaces.join(", ")}.\nQuesta funzione chiamerà le API reali nella fase 2.`;
+    const message = `Mock inviato a: ${marketplaces.join(", ")}.\nL'annuncio viene anche aggiunto alla vetrina e-commerce proprietaria.\nQuesta funzione chiamerà le API reali nella fase 2.`;
     alert(message);
 }
 

--- a/docs/assets/js/store.js
+++ b/docs/assets/js/store.js
@@ -1,0 +1,86 @@
+/**
+ * store.js — Logica mock per la pagina e-commerce Rinnova
+ * -------------------------------------------------------
+ * Questo script gestisce la simulazione dei filtri di categoria e
+ * aggiorna dinamicamente il riepilogo del catalogo. Le funzioni sono
+ * pensate per essere sostituite da chiamate API o da un data-store reale.
+ */
+
+const filterButtons = document.querySelectorAll('[data-filter]');
+const productCards = document.querySelectorAll('.product-card[data-category]');
+const summaryElement = document.getElementById('catalogue-summary');
+
+/**
+ * Aggiorna lo stato attivo dei pulsanti filtro per fornire feedback visivo.
+ */
+function setActiveFilter(button) {
+    filterButtons.forEach((btn) => btn.classList.remove('is-active'));
+    button.classList.add('is-active');
+}
+
+/**
+ * Mostra o nasconde le schede prodotto in base alla categoria selezionata.
+ * @param {string} filter - Categoria selezionata, "all" per mostrare tutto.
+ */
+function applyFilter(filter) {
+    let visibleCount = 0;
+
+    productCards.forEach((card) => {
+        const matches = filter === 'all' || card.dataset.category === filter;
+        card.classList.toggle('is-hidden', !matches);
+        card.setAttribute('aria-hidden', matches ? 'false' : 'true');
+        if (matches) {
+            visibleCount += 1;
+        }
+    });
+
+    if (summaryElement) {
+        const label = filter === 'all' ? 'prodotti disponibili' : `prodotti nella categoria "${mapFilterToLabel(filter)}"`;
+        summaryElement.textContent = `${visibleCount} ${label}`;
+    }
+}
+
+/**
+ * Converte il codice filtro in un'etichetta leggibile.
+ * @param {string} filter
+ * @returns {string}
+ */
+function mapFilterToLabel(filter) {
+    const labels = {
+        moda: 'Moda e accessori',
+        tech: 'Tech ricondizionato',
+        casa: 'Casa & design',
+        green: 'Upcycling & materiali',
+    };
+
+    return labels[filter] || 'tutte le categorie';
+}
+
+/**
+ * Gestisce il click sui filtri applicando le trasformazioni necessarie.
+ * @param {MouseEvent} event
+ */
+function handleFilterClick(event) {
+    const button = event.currentTarget;
+    const filter = button.dataset.filter;
+    setActiveFilter(button);
+    applyFilter(filter);
+}
+
+/**
+ * Inizializza gli event listener della pagina store.
+ */
+function initStore() {
+    if (!filterButtons.length) {
+        return;
+    }
+
+    filterButtons.forEach((button) => {
+        button.addEventListener('click', handleFilterClick);
+    });
+
+    // Imposta lo stato iniziale mostrando tutte le categorie.
+    applyFilter('all');
+}
+
+initStore();

--- a/docs/ecommerce.html
+++ b/docs/ecommerce.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rinnova · Mockup E-commerce dedicato</title>
+    <!--
+        Pagina mockup dedicata alla vetrina e-commerce proprietaria.
+        Riutilizza gli stili principali e introduce componenti per filtri e schede prodotto.
+        Pensata per mostrare come gli annunci generati possano essere raccolti in un catalogo navigabile.
+    -->
+    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container site-header__content">
+            <a class="site-header__brand" href="index.html">Rinnova</a>
+            <nav class="site-header__nav" aria-label="Navigazione principale">
+                <a href="index.html#upload-area">Genera annuncio</a>
+                <a href="ecommerce.html" aria-current="page">E-commerce dedicato</a>
+                <a href="index.html#integrazioni">Integrazioni marketplace</a>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero hero--subpage">
+            <div class="hero__overlay"></div>
+            <div class="hero__content container">
+                <div>
+                    <p class="hero__eyebrow">Catalogo proprietario</p>
+                    <h1>Organizza gli annunci generati in uno store intuitivo</h1>
+                    <p class="hero__subtitle">
+                        Questa anteprima mostra come gli oggetti valutati dall'IA possano essere raccolti in un e-commerce
+                        minimale ma completo: categorie, filtri rapidi, call-to-action verso marketplace esterni e schede di
+                        prodotto pronte per la vendita.
+                    </p>
+                    <div class="hero__cta">
+                        <a class="button button--light" href="#catalogo">Esplora il catalogo</a>
+                        <a class="button button--ghost" href="index.html#upload-area">Genera un nuovo annuncio</a>
+                    </div>
+                </div>
+                <div class="hero__card" aria-hidden="true">
+                    <div class="hero__card-header">
+                        <span class="dot"></span>
+                        <span class="dot"></span>
+                        <span class="dot"></span>
+                    </div>
+                    <div class="hero__card-body">
+                        <p class="hero__step"><span>1</span> Carica e analizza</p>
+                        <p class="hero__step"><span>2</span> Pubblica su marketplace</p>
+                        <p class="hero__step"><span>3</span> Metti in vetrina qui</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="catalogo">
+            <div class="container grid grid--two-columns">
+                <aside class="panel panel--filters" aria-label="Filtri catalogo">
+                    <h2>Filtra per categoria</h2>
+                    <p class="panel__subtitle">Seleziona una categoria per simulare il comportamento dei filtri lato utente.</p>
+                    <div class="filter-buttons" role="group" aria-label="Seleziona categoria">
+                        <button class="filter-button is-active" type="button" data-filter="all">Tutte</button>
+                        <button class="filter-button" type="button" data-filter="moda">Moda e accessori</button>
+                        <button class="filter-button" type="button" data-filter="tech">Tech ricondizionato</button>
+                        <button class="filter-button" type="button" data-filter="casa">Casa &amp; design</button>
+                        <button class="filter-button" type="button" data-filter="green">Upcycling &amp; materiali</button>
+                    </div>
+                    <div class="panel panel--mini">
+                        <h3>Mockup azioni gestore</h3>
+                        <ul class="checklist">
+                            <li>Attiva/disattiva visibilità per marketplace esterni.</li>
+                            <li>Segna oggetti come "In evidenza" o "Nuovo".</li>
+                            <li>Scarica report CSV delle performance (futuro).</li>
+                        </ul>
+                    </div>
+                </aside>
+
+                <div class="catalogue" aria-live="polite">
+                    <p class="catalogue__summary" id="catalogue-summary">4 prodotti disponibili</p>
+                    <article class="product-card" data-category="moda">
+                        <p class="product-card__category">Moda vintage</p>
+                        <h3>Borsa a spalla in pelle rigenerata</h3>
+                        <p class="product-card__price">€ 48</p>
+                        <p class="product-card__description">
+                            Analisi IA: stato molto buono, dettagli originali preservati, inclusa confezione antipolvere.
+                        </p>
+                        <ul class="product-card__meta">
+                            <li>Disponibile in negozio e su Vinted</li>
+                            <li>Ultimo restauro: marzo 2024</li>
+                        </ul>
+                        <div class="product-card__actions">
+                            <a class="button" href="#" aria-label="Anteprima annuncio borsa rigenerata">Anteprima annuncio</a>
+                            <a class="button button--ghost" href="#" aria-label="Pubblica su Vinted">Pubblica su Vinted</a>
+                        </div>
+                    </article>
+
+                    <article class="product-card" data-category="tech">
+                        <p class="product-card__category">Tech ricondizionato</p>
+                        <h3>Notebook 14" eco-upgrade</h3>
+                        <p class="product-card__price">€ 389</p>
+                        <p class="product-card__description">
+                            Processore quad-core, SSD 512GB nuovo, batteria sostituita. Garanzia laboratorio 12 mesi.
+                        </p>
+                        <ul class="product-card__meta">
+                            <li>Disponibile su eBay e Subito</li>
+                            <li>Rating qualità: 4.7/5</li>
+                        </ul>
+                        <div class="product-card__actions">
+                            <a class="button" href="#" aria-label="Anteprima annuncio notebook">Anteprima annuncio</a>
+                            <a class="button button--ghost" href="#" aria-label="Pubblica su eBay">Pubblica su eBay</a>
+                        </div>
+                    </article>
+
+                    <article class="product-card" data-category="casa">
+                        <p class="product-card__category">Casa &amp; design</p>
+                        <h3>Lampada da tavolo anni '70</h3>
+                        <p class="product-card__price">€ 95</p>
+                        <p class="product-card__description">
+                            Struttura in ottone lucidato, impianto elettrico certificato, diffusore in vetro satinato.
+                        </p>
+                        <ul class="product-card__meta">
+                            <li>Solo ritiro in sede o spedizione assicurata</li>
+                            <li>In evidenza nella home</li>
+                        </ul>
+                        <div class="product-card__actions">
+                            <a class="button" href="#" aria-label="Anteprima annuncio lampada">Anteprima annuncio</a>
+                            <a class="button button--ghost" href="#" aria-label="Pubblica su Subito">Pubblica su Subito</a>
+                        </div>
+                    </article>
+
+                    <article class="product-card" data-category="green">
+                        <p class="product-card__category">Upcycling creativo</p>
+                        <h3>Set tavolini pallet industrial</h3>
+                        <p class="product-card__price">€ 180</p>
+                        <p class="product-card__description">
+                            Realizzati con pallet recuperati, trattamento antitarlo, superficie resinata effetto satinato.
+                        </p>
+                        <ul class="product-card__meta">
+                            <li>Kit di montaggio incluso</li>
+                            <li>Disponibilità limitata: 4 pezzi</li>
+                        </ul>
+                        <div class="product-card__actions">
+                            <a class="button" href="#" aria-label="Anteprima annuncio tavolini">Anteprima annuncio</a>
+                            <a class="button button--ghost" href="#" aria-label="Condividi catalogo">Condividi catalogo</a>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--alt">
+            <div class="container grid grid--features">
+                <article class="feature">
+                    <h3>Esperienza cliente chiara</h3>
+                    <p>Gallery leggibili, tag di stato e call-to-action pensati per guidare all'acquisto.</p>
+                </article>
+                <article class="feature">
+                    <h3>Gestione operatori</h3>
+                    <p>Ogni scheda mostra suggerimenti su dove pubblicare l'annuncio e lo stato dei controlli qualità.</p>
+                </article>
+                <article class="feature">
+                    <h3>Pronto per crescere</h3>
+                    <p>Struttura modulare: facile aggiungere carrello, login cliente o tracking ordini nelle fasi successive.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container footer__content">
+            <p><strong>Rinnova · Mockup</strong> — sezione e-commerce proprietaria generata da AI.</p>
+            <p class="footer__links">
+                <a href="index.html#upload-area">Generatore annuncio</a>
+                <span aria-hidden="true">·</span>
+                <a href="index.html#integrazioni">Integrazioni marketplace</a>
+                <span aria-hidden="true">·</span>
+                <a href="documentation/SoftwareArchitecture.md">Documentazione</a>
+            </p>
+        </div>
+    </footer>
+
+    <script src="assets/js/store.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,17 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <header class="site-header">
+        <div class="container site-header__content">
+            <a class="site-header__brand" href="index.html">Rinnova</a>
+            <nav class="site-header__nav" aria-label="Navigazione principale">
+                <a href="index.html#upload-area">Genera annuncio</a>
+                <a href="ecommerce.html">E-commerce dedicato</a>
+                <a href="#integrazioni">Integrazioni marketplace</a>
+            </nav>
+        </div>
+    </header>
+
     <header class="hero">
         <div class="hero__overlay"></div>
         <div class="hero__content container">
@@ -109,7 +120,68 @@
             </div>
         </section>
 
-        <section class="section section--alt">
+        <section class="section" id="ecommerce-preview">
+            <div class="container grid grid--two-columns">
+                <div class="panel panel--info">
+                    <h2>Il tuo e-commerce proprietario, pronto da mostrare</h2>
+                    <p class="panel__subtitle">
+                        Accanto alla pubblicazione sui marketplace esterni, Rinnova propone anche uno spazio di vendita
+                        proprietario dove catalogare gli annunci generati e guidare i clienti tra categorie e offerte.
+                    </p>
+                    <ul class="checklist">
+                        <li>Catalogo suddiviso per categorie con filtri rapidi.</li>
+                        <li>Schede prodotto complete di valutazione, stato e call-to-action.</li>
+                        <li>Link diretti a marketplace esterni per pubblicare in un clic.</li>
+                    </ul>
+                    <div class="panel__actions">
+                        <a class="button" href="ecommerce.html">Apri mockup e-commerce</a>
+                        <a class="button button--ghost" href="#integrazioni">Scopri le integrazioni</a>
+                    </div>
+                </div>
+
+                <div class="panel panel--store-preview" aria-hidden="true">
+                    <div class="store-preview__header">
+                        <span class="dot"></span>
+                        <span class="dot"></span>
+                        <span class="dot"></span>
+                    </div>
+                    <div class="store-preview__body">
+                        <article class="product-card">
+                            <p class="product-card__category">Moda vintage</p>
+                            <h3>Borsa pelle rigenerata</h3>
+                            <p class="product-card__price">€ 48</p>
+                            <p class="product-card__description">Stato ottimo, tracolla regolabile, lucidatura professionale.</p>
+                            <div class="product-card__tags">
+                                <span>Pronto alla spedizione</span>
+                                <span>Descrizione IA</span>
+                            </div>
+                        </article>
+                        <article class="product-card">
+                            <p class="product-card__category">Tech ricondizionato</p>
+                            <h3>Tablet 10" con cover</h3>
+                            <p class="product-card__price">€ 129</p>
+                            <p class="product-card__description">Batteria al 90%, caricatore incluso, garanzia 12 mesi.</p>
+                            <div class="product-card__tags">
+                                <span>Pubblicato su eBay</span>
+                                <span>Checklist qualità</span>
+                            </div>
+                        </article>
+                        <article class="product-card">
+                            <p class="product-card__category">Casa &amp; design</p>
+                            <h3>Sedia mid-century</h3>
+                            <p class="product-card__price">€ 210</p>
+                            <p class="product-card__description">Legno restaurato, imbottitura nuova, pezzo unico 1968.</p>
+                            <div class="product-card__tags">
+                                <span>In evidenza</span>
+                                <span>Link Vinted</span>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--alt" id="integrazioni">
             <div class="container grid grid--features">
                 <article class="feature">
                     <h3>Trasparente per il team</h3>
@@ -134,6 +206,8 @@
                 <a href="documentation/SoftwareArchitecture.md">Documentazione</a>
                 <span aria-hidden="true">·</span>
                 <a href="#upload-area">Torna al form</a>
+                <span aria-hidden="true">·</span>
+                <a href="ecommerce.html">Vai all'e-commerce</a>
             </p>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- introduce a sticky navigation bar that links the announcement generator, marketplace integrations, and the new e-commerce mockup
- add an ecommerce.html page with filterable catalogue cards powered by a lightweight store.js mock
- expand shared styles and update the share mock message to present the dedicated storefront alongside external marketplaces

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58c189f4c832a84d26e24a61e063a