### PR TITLE
Remove top navigation bar from mockup pages

### DIFF
--- a/docs/ecommerce.html
+++ b/docs/ecommerce.html
@@ -15,17 +15,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-    <header class="site-header">
-        <div class="container site-header__content">
-            <a class="site-header__brand" href="index.html">Rinnova</a>
-            <nav class="site-header__nav" aria-label="Navigazione principale">
-                <a href="index.html#upload-area">Genera annuncio</a>
-                <a href="ecommerce.html" aria-current="page">E-commerce dedicato</a>
-                <a href="index.html#integrazioni">Integrazioni marketplace</a>
-            </nav>
-        </div>
-    </header>
-
     <main>
         <section class="hero hero--subpage">
             <div class="hero__overlay"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,17 +15,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-    <header class="site-header">
-        <div class="container site-header__content">
-            <a class="site-header__brand" href="index.html">Rinnova</a>
-            <nav class="site-header__nav" aria-label="Navigazione principale">
-                <a href="index.html#upload-area">Genera annuncio</a>
-                <a href="ecommerce.html">E-commerce dedicato</a>
-                <a href="#integrazioni">Integrazioni marketplace</a>
-            </nav>
-        </div>
-    </header>
-
     <header class="hero">
         <div class="hero__overlay"></div>
         <div class="hero__content container">


### PR DESCRIPTION
## Summary
- remove the global navigation header from the homepage and ecommerce mockup so the white bar no longer appears

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e58e390160832a8ac48449bd83b94e