### PR TITLE
Refine landing toggle for workflow and e-commerce

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -95,7 +95,8 @@ img {
 
 .site-header__nav a:hover,
 .site-header__nav a:focus,
-.site-header__nav a[aria-current="page"] {
+.site-header__nav a[aria-current="page"],
+.site-header__nav a.is-active {
     background: rgba(47, 139, 253, 0.12);
     color: var(--color-primary-dark);
 }
@@ -183,6 +184,76 @@ img {
     height: 28px;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.3);
+}
+
+.view-switcher {
+    background: #fff;
+    padding: 40px 0 0;
+}
+
+.view-switcher__buttons {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.view-switcher__button {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 32px;
+    padding-right: 56px;
+    padding-bottom: 56px;
+    border-radius: var(--radius-large);
+    border: 1px solid rgba(28, 77, 216, 0.12);
+    background: linear-gradient(135deg, rgba(47, 139, 253, 0.08), rgba(0, 198, 174, 0.08));
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+    text-align: left;
+}
+
+.view-switcher__label {
+    font-size: 1.2rem;
+}
+
+.view-switcher__button .view-switcher__subtitle {
+    font-weight: 400;
+    color: var(--color-muted);
+}
+
+.view-switcher__icon {
+    position: absolute;
+    bottom: 24px;
+    right: 24px;
+    font-size: 1.5rem;
+    color: var(--color-primary-dark);
+}
+
+.view-switcher__button:hover,
+.view-switcher__button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-soft);
+    border-color: rgba(47, 139, 253, 0.35);
+}
+
+.view-switcher__button.is-active {
+    background: linear-gradient(135deg, rgba(47, 139, 253, 0.22), rgba(0, 198, 174, 0.18));
+    border-color: rgba(47, 139, 253, 0.55);
+    box-shadow: var(--shadow-soft);
+}
+
+.view-panel {
+    display: none;
+}
+
+.view-panel.is-active {
+    display: block;
 }
 
 .section {
@@ -555,6 +626,39 @@ textarea:focus {
     color: rgba(255, 255, 255, 0.85);
 }
 
+.product-card__media {
+    position: relative;
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+    aspect-ratio: 4 / 3;
+    background: rgba(15, 23, 42, 0.08);
+}
+
+.product-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.product-card__badge {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.76);
+    color: #fff;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.product-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .product-card__price {
     font-weight: 600;
     font-size: 1.2rem;
@@ -638,6 +742,12 @@ textarea:focus {
     color: var(--color-primary-dark);
 }
 
+.filter-button[aria-pressed="true"] {
+    background: linear-gradient(135deg, rgba(47, 139, 253, 0.22), rgba(0, 198, 174, 0.18));
+    border-color: rgba(47, 139, 253, 0.6);
+    color: var(--color-primary-dark);
+}
+
 .feature {
     background: #f8faff;
     padding: 28px;
@@ -694,6 +804,10 @@ textarea:focus {
     .site-header__nav {
         justify-content: center;
     }
+
+    .view-switcher__buttons {
+        grid-template-columns: 1fr;
+    }
 }
 
 @media (max-width: 500px) {
@@ -711,5 +825,11 @@ textarea:focus {
 
     .site-header__nav {
         gap: 12px;
+    }
+
+    .view-switcher__button {
+        padding: 28px 24px;
+        padding-right: 52px;
+        padding-bottom: 52px;
     }
 }

--- a/docs/assets/images/README.md
+++ b/docs/assets/images/README.md
@@ -1,0 +1,11 @@
+# Cartella immagini mockup
+
+Inserire in questa directory le immagini utilizzate dalle schede prodotto dell'e-commerce mockup.
+I file attesi dal codice sono:
+
+- `vintage-bag.jpg`
+- `eco-notebook.jpg`
+- `vintage-lamp.jpg`
+- `pallet-tables.jpg`
+
+In questa fase restano segnaposto: è possibile sostituirli con foto reali salvandole con gli stessi nomi.

--- a/docs/assets/js/store.js
+++ b/docs/assets/js/store.js
@@ -14,8 +14,13 @@ const summaryElement = document.getElementById('catalogue-summary');
  * Aggiorna lo stato attivo dei pulsanti filtro per fornire feedback visivo.
  */
 function setActiveFilter(button) {
-    filterButtons.forEach((btn) => btn.classList.remove('is-active'));
+    filterButtons.forEach((btn) => {
+        btn.classList.remove('is-active');
+        btn.setAttribute('aria-pressed', 'false');
+    });
+
     button.classList.add('is-active');
+    button.setAttribute('aria-pressed', 'true');
 }
 
 /**
@@ -68,6 +73,17 @@ function handleFilterClick(event) {
 }
 
 /**
+ * Ripristina lo stato iniziale dei filtri.
+ */
+function resetFilters() {
+    const defaultButton = document.querySelector('.filter-button[data-filter="all"]');
+    if (!defaultButton) return;
+
+    setActiveFilter(defaultButton);
+    applyFilter('all');
+}
+
+/**
  * Inizializza gli event listener della pagina store.
  */
 function initStore() {
@@ -80,7 +96,11 @@ function initStore() {
     });
 
     // Imposta lo stato iniziale mostrando tutte le categorie.
-    applyFilter('all');
+    resetFilters();
 }
 
 initStore();
+
+// Espone una funzione di utilità per ripristinare i filtri quando la vista viene riattivata.
+window.RinnovaStore = window.RinnovaStore || {};
+window.RinnovaStore.resetFilters = resetFilters;

--- a/docs/ecommerce.html
+++ b/docs/ecommerce.html
@@ -2,188 +2,27 @@
 <html lang="it">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=index.html?view=ecommerce#ecommerce-intro">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Rinnova · Mockup E-commerce dedicato</title>
     <!--
-        Pagina mockup dedicata alla vetrina e-commerce proprietaria.
-        Riutilizza gli stili principali e introduce componenti per filtri e schede prodotto.
-        Pensata per mostrare come gli annunci generati possano essere raccolti in un catalogo navigabile.
+        Pagina mantenuta per compatibilità: reindirizza alla nuova vista e-commerce
+        integrata nella landing page principale.
     -->
     <link rel="stylesheet" href="assets/css/style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-    <header class="site-header">
-        <div class="container site-header__content">
-            <a class="site-header__brand" href="index.html">Rinnova</a>
-            <nav class="site-header__nav" aria-label="Navigazione principale">
-                <a href="index.html#upload-area">Genera annuncio</a>
-                <a href="ecommerce.html" aria-current="page">E-commerce dedicato</a>
-                <a href="index.html#integrazioni">Integrazioni marketplace</a>
-            </nav>
-        </div>
-    </header>
-
-    <main>
-        <section class="hero hero--subpage">
-            <div class="hero__overlay"></div>
-            <div class="hero__content container">
-                <div>
-                    <p class="hero__eyebrow">Catalogo proprietario</p>
-                    <h1>Organizza gli annunci generati in uno store intuitivo</h1>
-                    <p class="hero__subtitle">
-                        Questa anteprima mostra come gli oggetti valutati dall'IA possano essere raccolti in un e-commerce
-                        minimale ma completo: categorie, filtri rapidi, call-to-action verso marketplace esterni e schede di
-                        prodotto pronte per la vendita.
-                    </p>
-                    <div class="hero__cta">
-                        <a class="button button--light" href="#catalogo">Esplora il catalogo</a>
-                        <a class="button button--ghost" href="index.html#upload-area">Genera un nuovo annuncio</a>
-                    </div>
-                </div>
-                <div class="hero__card" aria-hidden="true">
-                    <div class="hero__card-header">
-                        <span class="dot"></span>
-                        <span class="dot"></span>
-                        <span class="dot"></span>
-                    </div>
-                    <div class="hero__card-body">
-                        <p class="hero__step"><span>1</span> Carica e analizza</p>
-                        <p class="hero__step"><span>2</span> Pubblica su marketplace</p>
-                        <p class="hero__step"><span>3</span> Metti in vetrina qui</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <section class="section" id="catalogo">
-            <div class="container grid grid--two-columns">
-                <aside class="panel panel--filters" aria-label="Filtri catalogo">
-                    <h2>Filtra per categoria</h2>
-                    <p class="panel__subtitle">Seleziona una categoria per simulare il comportamento dei filtri lato utente.</p>
-                    <div class="filter-buttons" role="group" aria-label="Seleziona categoria">
-                        <button class="filter-button is-active" type="button" data-filter="all">Tutte</button>
-                        <button class="filter-button" type="button" data-filter="moda">Moda e accessori</button>
-                        <button class="filter-button" type="button" data-filter="tech">Tech ricondizionato</button>
-                        <button class="filter-button" type="button" data-filter="casa">Casa &amp; design</button>
-                        <button class="filter-button" type="button" data-filter="green">Upcycling &amp; materiali</button>
-                    </div>
-                    <div class="panel panel--mini">
-                        <h3>Mockup azioni gestore</h3>
-                        <ul class="checklist">
-                            <li>Attiva/disattiva visibilità per marketplace esterni.</li>
-                            <li>Segna oggetti come "In evidenza" o "Nuovo".</li>
-                            <li>Scarica report CSV delle performance (futuro).</li>
-                        </ul>
-                    </div>
-                </aside>
-
-                <div class="catalogue" aria-live="polite">
-                    <p class="catalogue__summary" id="catalogue-summary">4 prodotti disponibili</p>
-                    <article class="product-card" data-category="moda">
-                        <p class="product-card__category">Moda vintage</p>
-                        <h3>Borsa a spalla in pelle rigenerata</h3>
-                        <p class="product-card__price">€ 48</p>
-                        <p class="product-card__description">
-                            Analisi IA: stato molto buono, dettagli originali preservati, inclusa confezione antipolvere.
-                        </p>
-                        <ul class="product-card__meta">
-                            <li>Disponibile in negozio e su Vinted</li>
-                            <li>Ultimo restauro: marzo 2024</li>
-                        </ul>
-                        <div class="product-card__actions">
-                            <a class="button" href="#" aria-label="Anteprima annuncio borsa rigenerata">Anteprima annuncio</a>
-                            <a class="button button--ghost" href="#" aria-label="Pubblica su Vinted">Pubblica su Vinted</a>
-                        </div>
-                    </article>
-
-                    <article class="product-card" data-category="tech">
-                        <p class="product-card__category">Tech ricondizionato</p>
-                        <h3>Notebook 14" eco-upgrade</h3>
-                        <p class="product-card__price">€ 389</p>
-                        <p class="product-card__description">
-                            Processore quad-core, SSD 512GB nuovo, batteria sostituita. Garanzia laboratorio 12 mesi.
-                        </p>
-                        <ul class="product-card__meta">
-                            <li>Disponibile su eBay e Subito</li>
-                            <li>Rating qualità: 4.7/5</li>
-                        </ul>
-                        <div class="product-card__actions">
-                            <a class="button" href="#" aria-label="Anteprima annuncio notebook">Anteprima annuncio</a>
-                            <a class="button button--ghost" href="#" aria-label="Pubblica su eBay">Pubblica su eBay</a>
-                        </div>
-                    </article>
-
-                    <article class="product-card" data-category="casa">
-                        <p class="product-card__category">Casa &amp; design</p>
-                        <h3>Lampada da tavolo anni '70</h3>
-                        <p class="product-card__price">€ 95</p>
-                        <p class="product-card__description">
-                            Struttura in ottone lucidato, impianto elettrico certificato, diffusore in vetro satinato.
-                        </p>
-                        <ul class="product-card__meta">
-                            <li>Solo ritiro in sede o spedizione assicurata</li>
-                            <li>In evidenza nella home</li>
-                        </ul>
-                        <div class="product-card__actions">
-                            <a class="button" href="#" aria-label="Anteprima annuncio lampada">Anteprima annuncio</a>
-                            <a class="button button--ghost" href="#" aria-label="Pubblica su Subito">Pubblica su Subito</a>
-                        </div>
-                    </article>
-
-                    <article class="product-card" data-category="green">
-                        <p class="product-card__category">Upcycling creativo</p>
-                        <h3>Set tavolini pallet industrial</h3>
-                        <p class="product-card__price">€ 180</p>
-                        <p class="product-card__description">
-                            Realizzati con pallet recuperati, trattamento antitarlo, superficie resinata effetto satinato.
-                        </p>
-                        <ul class="product-card__meta">
-                            <li>Kit di montaggio incluso</li>
-                            <li>Disponibilità limitata: 4 pezzi</li>
-                        </ul>
-                        <div class="product-card__actions">
-                            <a class="button" href="#" aria-label="Anteprima annuncio tavolini">Anteprima annuncio</a>
-                            <a class="button button--ghost" href="#" aria-label="Condividi catalogo">Condividi catalogo</a>
-                        </div>
-                    </article>
-                </div>
-            </div>
-        </section>
-
-        <section class="section section--alt">
-            <div class="container grid grid--features">
-                <article class="feature">
-                    <h3>Esperienza cliente chiara</h3>
-                    <p>Gallery leggibili, tag di stato e call-to-action pensati per guidare all'acquisto.</p>
-                </article>
-                <article class="feature">
-                    <h3>Gestione operatori</h3>
-                    <p>Ogni scheda mostra suggerimenti su dove pubblicare l'annuncio e lo stato dei controlli qualità.</p>
-                </article>
-                <article class="feature">
-                    <h3>Pronto per crescere</h3>
-                    <p>Struttura modulare: facile aggiungere carrello, login cliente o tracking ordini nelle fasi successive.</p>
-                </article>
-            </div>
-        </section>
-    </main>
-
-    <footer class="footer">
-        <div class="container footer__content">
-            <p><strong>Rinnova · Mockup</strong> — sezione e-commerce proprietaria generata da AI.</p>
-            <p class="footer__links">
-                <a href="index.html#upload-area">Generatore annuncio</a>
-                <span aria-hidden="true">·</span>
-                <a href="index.html#integrazioni">Integrazioni marketplace</a>
-                <span aria-hidden="true">·</span>
-                <a href="documentation/SoftwareArchitecture.md">Documentazione</a>
+    <main class="section">
+        <div class="container">
+            <h1>Reindirizzamento alla vetrina e-commerce</h1>
+            <p>Stiamo caricando la nuova esperienza integrata. Se non vieni reindirizzato automaticamente, clicca il pulsante:</p>
+            <p>
+                <a class="button" href="index.html?view=ecommerce#ecommerce-intro">Apri l'e-commerce</a>
             </p>
         </div>
-    </footer>
-
-    <script src="assets/js/store.js"></script>
+    </main>
+    <script>
+        window.location.replace('index.html?view=ecommerce#ecommerce-intro');
+    </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,9 +19,9 @@
         <div class="container site-header__content">
             <a class="site-header__brand" href="index.html">Rinnova</a>
             <nav class="site-header__nav" aria-label="Navigazione principale">
-                <a href="index.html#upload-area">Genera annuncio</a>
-                <a href="ecommerce.html">E-commerce dedicato</a>
-                <a href="#integrazioni">Integrazioni marketplace</a>
+                <a href="#view-switcher" data-switch-target="workflow" data-scroll-target="upload-area" data-view-role="primary" class="is-active">Genera annuncio</a>
+                <a href="#view-switcher" data-switch-target="ecommerce" data-scroll-target="ecommerce-intro" data-view-role="primary">E-commerce dedicato</a>
+                <a href="#view-switcher" data-switch-target="workflow" data-scroll-target="workflow-integrazioni">Integrazioni marketplace</a>
             </nav>
         </div>
     </header>
@@ -37,7 +37,7 @@
                     classificazione, valutazione economica e descrizione persuasiva.
                 </p>
                 <div class="hero__cta">
-                    <a class="button button--light" href="#upload-area">Inizia ora</a>
+                    <a class="button button--light" href="#upload-area" data-switch-target="workflow" data-scroll-target="upload-area">Inizia ora</a>
                     <button class="button button--ghost" type="button" id="tour-button">Scopri il flusso</button>
                 </div>
             </div>
@@ -57,145 +57,312 @@
     </header>
 
     <main>
-        <section class="section" id="upload-area">
-            <div class="container grid">
-                <div class="panel panel--form">
-                    <h2>Carica il tuo oggetto</h2>
-                    <p class="panel__subtitle">Almeno una foto è obbligatoria; la descrizione è opzionale.</p>
-                    <form id="object-form" novalidate>
-                        <div class="form-group">
-                            <label for="photos">Foto dell'oggetto <span class="required">*</span></label>
-                            <div class="dropzone" id="dropzone" tabindex="0">
-                                <p>Trascina qui una o più immagini oppure <span class="highlight">selezionale</span></p>
-                                <input type="file" id="photos" name="photos" accept="image/*" multiple required>
-                            </div>
-                            <p class="form-hint">Formato consigliato: JPG o PNG, max 10MB per immagine.</p>
-                            <ul id="preview-list" class="preview-list" aria-live="polite"></ul>
-                        </div>
-
-                        <div class="form-group">
-                            <label for="description">Descrizione opzionale</label>
-                            <textarea id="description" name="description" rows="4" placeholder="Es. Marca, anno, eventuali difetti o particolarità..."></textarea>
-                        </div>
-
-                        <div class="form-actions">
-                            <button type="submit" class="button" id="analyze-button">Avvia analisi</button>
-                            <p class="form-legal">Nessun dato viene memorizzato: questa è una demo interattiva.</p>
-                        </div>
-                    </form>
-                </div>
-
-                <div class="panel panel--status" aria-live="polite" aria-atomic="true">
-                    <h2>Cosa sta facendo l'IA</h2>
-                    <ol class="status-timeline" id="status-timeline">
-                        <li data-step="upload" class="is-pending">
-                            <strong>Verifica dei file caricati</strong>
-                            <p>L'IA controlla formato, qualità e numero di foto.</p>
-                        </li>
-                        <li data-step="recognition" class="is-pending">
-                            <strong>Riconoscimento dell'oggetto</strong>
-                            <p>Il modello vision classifica categoria, marca e stato.</p>
-                        </li>
-                        <li data-step="valuation" class="is-pending">
-                            <strong>Ricerca del valore di mercato</strong>
-                            <p>Interroga marketplace e banche dati per stimare il prezzo.</p>
-                        </li>
-                        <li data-step="copywriting" class="is-pending">
-                            <strong>Generazione dell'annuncio</strong>
-                            <p>L'LLM scrive titolo, descrizione e call-to-action.</p>
-                        </li>
-                    </ol>
-
-                    <div class="result-card is-hidden" id="result-card">
-                        <h3>Anteprima annuncio</h3>
-                        <p class="result-card__title" id="result-title">–</p>
-                        <p class="result-card__price" id="result-price">–</p>
-                        <p class="result-card__body" id="result-description">Carica un oggetto per generare l'annuncio.</p>
-                        <div class="result-card__cta">
-                            <button type="button" class="button button--ghost" id="download-button">Scarica bozza JSON</button>
-                            <button type="button" class="button button--light" id="share-button">Condividi via API (mock)</button>
-                        </div>
-                    </div>
-                </div>
+        <section class="view-switcher" id="view-switcher">
+            <div class="container view-switcher__buttons">
+                <button type="button" class="view-switcher__button is-active" data-switch-target="workflow" data-scroll-target="upload-area">
+                    <span class="view-switcher__label">Workflow annuncio guidato</span>
+                    <span class="view-switcher__subtitle">Upload immagini, descrizione e timeline IA passo passo.</span>
+                </button>
+                <button type="button" class="view-switcher__button" data-switch-target="ecommerce" data-scroll-target="ecommerce-intro">
+                    <span class="view-switcher__label">Vetrina e-commerce</span>
+                    <span class="view-switcher__subtitle">Catalogo con categorie, filtri e schede illustrate.</span>
+                    <span class="view-switcher__icon" aria-hidden="true">↗</span>
+                </button>
             </div>
         </section>
 
-        <section class="section" id="ecommerce-preview">
-            <div class="container grid grid--two-columns">
-                <div class="panel panel--info">
-                    <h2>Il tuo e-commerce proprietario, pronto da mostrare</h2>
-                    <p class="panel__subtitle">
-                        Accanto alla pubblicazione sui marketplace esterni, Rinnova propone anche uno spazio di vendita
-                        proprietario dove catalogare gli annunci generati e guidare i clienti tra categorie e offerte.
-                    </p>
-                    <ul class="checklist">
-                        <li>Catalogo suddiviso per categorie con filtri rapidi.</li>
-                        <li>Schede prodotto complete di valutazione, stato e call-to-action.</li>
-                        <li>Link diretti a marketplace esterni per pubblicare in un clic.</li>
-                    </ul>
-                    <div class="panel__actions">
-                        <a class="button" href="ecommerce.html">Apri mockup e-commerce</a>
-                        <a class="button button--ghost" href="#integrazioni">Scopri le integrazioni</a>
-                    </div>
-                </div>
+        <section class="view-panel is-active" id="workflow-view" data-view-panel="workflow">
+            <section class="section" id="upload-area">
+                <div class="container grid">
+                    <div class="panel panel--form">
+                        <h2>Carica il tuo oggetto</h2>
+                        <p class="panel__subtitle">Almeno una foto è obbligatoria; la descrizione è opzionale.</p>
+                        <form id="object-form" novalidate>
+                            <div class="form-group">
+                                <label for="photos">Foto dell'oggetto <span class="required">*</span></label>
+                                <div class="dropzone" id="dropzone" tabindex="0">
+                                    <p>Trascina qui una o più immagini oppure <span class="highlight">selezionale</span></p>
+                                    <input type="file" id="photos" name="photos" accept="image/*" multiple required>
+                                </div>
+                                <p class="form-hint">Formato consigliato: JPG o PNG, max 10MB per immagine.</p>
+                                <ul id="preview-list" class="preview-list" aria-live="polite"></ul>
+                            </div>
 
-                <div class="panel panel--store-preview" aria-hidden="true">
-                    <div class="store-preview__header">
-                        <span class="dot"></span>
-                        <span class="dot"></span>
-                        <span class="dot"></span>
+                            <div class="form-group">
+                                <label for="description">Descrizione opzionale</label>
+                                <textarea id="description" name="description" rows="4" placeholder="Es. Marca, anno, eventuali difetti o particolarità..."></textarea>
+                            </div>
+
+                            <div class="form-actions">
+                                <button type="submit" class="button" id="analyze-button">Avvia analisi</button>
+                                <p class="form-legal">Nessun dato viene memorizzato: questa è una demo interattiva.</p>
+                            </div>
+                        </form>
                     </div>
-                    <div class="store-preview__body">
-                        <article class="product-card">
-                            <p class="product-card__category">Moda vintage</p>
-                            <h3>Borsa pelle rigenerata</h3>
-                            <p class="product-card__price">€ 48</p>
-                            <p class="product-card__description">Stato ottimo, tracolla regolabile, lucidatura professionale.</p>
-                            <div class="product-card__tags">
-                                <span>Pronto alla spedizione</span>
-                                <span>Descrizione IA</span>
+
+                    <div class="panel panel--status" aria-live="polite" aria-atomic="true">
+                        <h2>Cosa sta facendo l'IA</h2>
+                        <ol class="status-timeline" id="status-timeline">
+                            <li data-step="upload" class="is-pending">
+                                <strong>Verifica dei file caricati</strong>
+                                <p>L'IA controlla formato, qualità e numero di foto.</p>
+                            </li>
+                            <li data-step="recognition" class="is-pending">
+                                <strong>Riconoscimento dell'oggetto</strong>
+                                <p>Il modello vision classifica categoria, marca e stato.</p>
+                            </li>
+                            <li data-step="valuation" class="is-pending">
+                                <strong>Ricerca del valore di mercato</strong>
+                                <p>Interroga marketplace e banche dati per stimare il prezzo.</p>
+                            </li>
+                            <li data-step="copywriting" class="is-pending">
+                                <strong>Generazione dell'annuncio</strong>
+                                <p>L'LLM scrive titolo, descrizione e call-to-action.</p>
+                            </li>
+                        </ol>
+
+                        <div class="result-card is-hidden" id="result-card">
+                            <h3>Anteprima annuncio</h3>
+                            <p class="result-card__title" id="result-title">–</p>
+                            <p class="result-card__price" id="result-price">–</p>
+                            <p class="result-card__body" id="result-description">Carica un oggetto per generare l'annuncio.</p>
+                            <div class="result-card__cta">
+                                <button type="button" class="button button--ghost" id="download-button">Scarica bozza JSON</button>
+                                <button type="button" class="button button--light" id="share-button">Condividi via API (mock)</button>
                             </div>
-                        </article>
-                        <article class="product-card">
-                            <p class="product-card__category">Tech ricondizionato</p>
-                            <h3>Tablet 10" con cover</h3>
-                            <p class="product-card__price">€ 129</p>
-                            <p class="product-card__description">Batteria al 90%, caricatore incluso, garanzia 12 mesi.</p>
-                            <div class="product-card__tags">
-                                <span>Pubblicato su eBay</span>
-                                <span>Checklist qualità</span>
-                            </div>
-                        </article>
-                        <article class="product-card">
-                            <p class="product-card__category">Casa &amp; design</p>
-                            <h3>Sedia mid-century</h3>
-                            <p class="product-card__price">€ 210</p>
-                            <p class="product-card__description">Legno restaurato, imbottitura nuova, pezzo unico 1968.</p>
-                            <div class="product-card__tags">
-                                <span>In evidenza</span>
-                                <span>Link Vinted</span>
-                            </div>
-                        </article>
+                        </div>
                     </div>
                 </div>
-            </div>
+            </section>
+
+            <section class="section section--alt" id="workflow-integrazioni">
+                <div class="container grid grid--features">
+                    <article class="feature">
+                        <h3>Trasparente per il team</h3>
+                        <p>Ogni step è spiegato e tracciato così il cliente può capire cosa succede dietro le quinte.</p>
+                    </article>
+                    <article class="feature">
+                        <h3>Pronta per le API</h3>
+                        <p>Le funzioni JavaScript sono isolate: basta collegarle a un backend reale per andare live.</p>
+                    </article>
+                    <article class="feature">
+                        <h3>Usabile per chiunque</h3>
+                        <p>Form guidato, controlli lato client e suggerimenti aiutano anche gli utenti meno esperti.</p>
+                    </article>
+                </div>
+            </section>
         </section>
 
-        <section class="section section--alt" id="integrazioni">
-            <div class="container grid grid--features">
-                <article class="feature">
-                    <h3>Trasparente per il team</h3>
-                    <p>Ogni step è spiegato e tracciato così il cliente può capire cosa succede dietro le quinte.</p>
-                </article>
-                <article class="feature">
-                    <h3>Pronta per le API</h3>
-                    <p>Le funzioni JavaScript sono isolate: basta collegarle a un backend reale per andare live.</p>
-                </article>
-                <article class="feature">
-                    <h3>Usabile per chiunque</h3>
-                    <p>Form guidato, controlli lato client e suggerimenti aiutano anche gli utenti meno esperti.</p>
-                </article>
-            </div>
+        <section class="view-panel" id="ecommerce-view" data-view-panel="ecommerce" hidden>
+            <section class="section section--alt view-panel__intro" id="ecommerce-intro">
+                <div class="container grid grid--two-columns">
+                    <div class="panel panel--info">
+                        <h2>Il tuo e-commerce proprietario, pronto da mostrare</h2>
+                        <p class="panel__subtitle">
+                            Accanto alla pubblicazione sui marketplace esterni, Rinnova propone anche uno spazio di vendita
+                            proprietario dove catalogare gli annunci generati e guidare i clienti tra categorie e offerte.
+                        </p>
+                        <ul class="checklist">
+                            <li>Catalogo suddiviso per categorie con filtri rapidi.</li>
+                            <li>Schede prodotto complete di valutazione, stato e call-to-action.</li>
+                            <li>Link diretti a marketplace esterni per pubblicare in un clic.</li>
+                        </ul>
+                        <div class="panel__actions">
+                            <a class="button" href="#upload-area" data-switch-target="workflow" data-scroll-target="upload-area">Genera un nuovo annuncio</a>
+                            <a class="button button--ghost" href="#workflow-integrazioni" data-switch-target="workflow" data-scroll-target="workflow-integrazioni">Scopri le integrazioni</a>
+                        </div>
+                    </div>
+
+                    <div class="panel panel--store-preview" aria-hidden="true">
+                        <div class="store-preview__header">
+                            <span class="dot"></span>
+                            <span class="dot"></span>
+                            <span class="dot"></span>
+                        </div>
+                        <div class="store-preview__body">
+                            <article class="product-card">
+                                <p class="product-card__category">Moda vintage</p>
+                                <h3>Borsa pelle rigenerata</h3>
+                                <p class="product-card__price">€ 48</p>
+                                <p class="product-card__description">Stato ottimo, tracolla regolabile, lucidatura professionale.</p>
+                                <div class="product-card__tags">
+                                    <span>Pronto alla spedizione</span>
+                                    <span>Descrizione IA</span>
+                                </div>
+                            </article>
+                            <article class="product-card">
+                                <p class="product-card__category">Tech ricondizionato</p>
+                                <h3>Tablet 10" con cover</h3>
+                                <p class="product-card__price">€ 129</p>
+                                <p class="product-card__description">Batteria al 90%, caricatore incluso, garanzia 12 mesi.</p>
+                                <div class="product-card__tags">
+                                    <span>Pubblicato su eBay</span>
+                                    <span>Checklist qualità</span>
+                                </div>
+                            </article>
+                            <article class="product-card">
+                                <p class="product-card__category">Casa &amp; design</p>
+                                <h3>Sedia mid-century</h3>
+                                <p class="product-card__price">€ 210</p>
+                                <p class="product-card__description">Legno restaurato, imbottitura nuova, pezzo unico 1968.</p>
+                                <div class="product-card__tags">
+                                    <span>In evidenza</span>
+                                    <span>Link Vinted</span>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section" id="ecommerce-catalogue">
+                <div class="container grid grid--two-columns">
+                    <aside class="panel panel--filters" aria-label="Filtri catalogo">
+                        <h2>Filtra per categoria</h2>
+                        <p class="panel__subtitle">Seleziona una categoria per simulare il comportamento dei filtri lato utente.</p>
+                        <div class="filter-buttons" role="group" aria-label="Seleziona categoria">
+                            <button class="filter-button is-active" type="button" data-filter="all" aria-pressed="true">Tutte</button>
+                            <button class="filter-button" type="button" data-filter="moda" aria-pressed="false">Moda e accessori</button>
+                            <button class="filter-button" type="button" data-filter="tech" aria-pressed="false">Tech ricondizionato</button>
+                            <button class="filter-button" type="button" data-filter="casa" aria-pressed="false">Casa &amp; design</button>
+                            <button class="filter-button" type="button" data-filter="green" aria-pressed="false">Upcycling &amp; materiali</button>
+                        </div>
+                        <div class="panel panel--mini">
+                            <h3>Mockup azioni gestore</h3>
+                            <ul class="checklist">
+                                <li>Attiva/disattiva visibilità per marketplace esterni.</li>
+                                <li>Segna oggetti come "In evidenza" o "Nuovo".</li>
+                                <li>Scarica report CSV delle performance (futuro).</li>
+                            </ul>
+                        </div>
+                    </aside>
+
+                    <div class="catalogue" aria-live="polite">
+                        <p class="catalogue__summary" id="catalogue-summary">4 prodotti disponibili</p>
+
+                        <article class="product-card" data-category="moda">
+                            <div class="product-card__media">
+                                <img src="assets/images/vintage-bag.jpg" alt="Borsa a spalla in pelle rigenerata color cognac" loading="lazy">
+                                <span class="product-card__badge">Moda vintage</span>
+                            </div>
+                            <div class="product-card__content">
+                                <h3>Borsa a spalla in pelle rigenerata</h3>
+                                <p class="product-card__price">€ 48</p>
+                                <p class="product-card__description">
+                                    Analisi IA: stato molto buono, dettagli originali preservati, inclusa confezione antipolvere.
+                                </p>
+                                <ul class="product-card__meta">
+                                    <li>Disponibile in negozio e su Vinted</li>
+                                    <li>Ultimo restauro: marzo 2024</li>
+                                </ul>
+                                <div class="product-card__tags">
+                                    <span>Descrizione IA</span>
+                                    <span>Eco-friendly</span>
+                                </div>
+                                <div class="product-card__actions">
+                                    <a class="button" href="#" aria-label="Anteprima annuncio borsa rigenerata">Anteprima annuncio</a>
+                                    <a class="button button--ghost" href="#" aria-label="Pubblica su Vinted">Pubblica su Vinted</a>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="product-card" data-category="tech">
+                            <div class="product-card__media">
+                                <img src="assets/images/eco-notebook.jpg" alt="Notebook ricondizionato da 14 pollici con finitura grigia" loading="lazy">
+                                <span class="product-card__badge">Tech ricondizionato</span>
+                            </div>
+                            <div class="product-card__content">
+                                <h3>Notebook 14" eco-upgrade</h3>
+                                <p class="product-card__price">€ 389</p>
+                                <p class="product-card__description">
+                                    Processore quad-core, SSD 512GB nuovo, batteria sostituita. Garanzia laboratorio 12 mesi.
+                                </p>
+                                <ul class="product-card__meta">
+                                    <li>Disponibile su eBay e Subito</li>
+                                    <li>Rating qualità: 4.7/5</li>
+                                </ul>
+                                <div class="product-card__tags">
+                                    <span>Pronto al ritiro</span>
+                                    <span>Check list qualità</span>
+                                </div>
+                                <div class="product-card__actions">
+                                    <a class="button" href="#" aria-label="Anteprima annuncio notebook">Anteprima annuncio</a>
+                                    <a class="button button--ghost" href="#" aria-label="Pubblica su eBay">Pubblica su eBay</a>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="product-card" data-category="casa">
+                            <div class="product-card__media">
+                                <img src="assets/images/vintage-lamp.jpg" alt="Lampada da tavolo anni settanta in ottone lucidato" loading="lazy">
+                                <span class="product-card__badge">Casa &amp; design</span>
+                            </div>
+                            <div class="product-card__content">
+                                <h3>Lampada da tavolo anni '70</h3>
+                                <p class="product-card__price">€ 95</p>
+                                <p class="product-card__description">
+                                    Struttura in ottone lucidato, impianto elettrico certificato, diffusore in vetro satinato.
+                                </p>
+                                <ul class="product-card__meta">
+                                    <li>Solo ritiro in sede o spedizione assicurata</li>
+                                    <li>In evidenza nella home</li>
+                                </ul>
+                                <div class="product-card__tags">
+                                    <span>Verificato laboratorio</span>
+                                    <span>Illuminazione vintage</span>
+                                </div>
+                                <div class="product-card__actions">
+                                    <a class="button" href="#" aria-label="Anteprima annuncio lampada">Anteprima annuncio</a>
+                                    <a class="button button--ghost" href="#" aria-label="Pubblica su Subito">Pubblica su Subito</a>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="product-card" data-category="green">
+                            <div class="product-card__media">
+                                <img src="assets/images/pallet-tables.jpg" alt="Set di tavolini industrial realizzati con pallet riciclati" loading="lazy">
+                                <span class="product-card__badge">Upcycling &amp; materiali</span>
+                            </div>
+                            <div class="product-card__content">
+                                <h3>Set tavolini pallet industrial</h3>
+                                <p class="product-card__price">€ 180</p>
+                                <p class="product-card__description">
+                                    Realizzati con pallet recuperati, trattamento antitarlo, superficie resinata effetto satinato.
+                                </p>
+                                <ul class="product-card__meta">
+                                    <li>Kit di montaggio incluso</li>
+                                    <li>Disponibilità limitata: 4 pezzi</li>
+                                </ul>
+                                <div class="product-card__tags">
+                                    <span>Materiali recuperati</span>
+                                    <span>Artigianato locale</span>
+                                </div>
+                                <div class="product-card__actions">
+                                    <a class="button" href="#" aria-label="Anteprima annuncio tavolini">Anteprima annuncio</a>
+                                    <a class="button button--ghost" href="#" aria-label="Condividi catalogo">Condividi catalogo</a>
+                                </div>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section section--alt" id="ecommerce-plus">
+                <div class="container grid grid--features">
+                    <article class="feature">
+                        <h3>Esperienza cliente chiara</h3>
+                        <p>Gallery leggibili, tag di stato e call-to-action pensati per guidare all'acquisto.</p>
+                    </article>
+                    <article class="feature">
+                        <h3>Gestione operatori</h3>
+                        <p>Ogni scheda mostra suggerimenti su dove pubblicare l'annuncio e lo stato dei controlli qualità.</p>
+                    </article>
+                    <article class="feature">
+                        <h3>Pronto per crescere</h3>
+                        <p>Struttura modulare: facile aggiungere carrello, login cliente o tracking ordini nelle fasi successive.</p>
+                    </article>
+                </div>
+            </section>
         </section>
     </main>
 
@@ -203,15 +370,16 @@
         <div class="container footer__content">
             <p><strong>Rinnova · Mockup</strong> — mockup frontend generato da AI per la fase di concept.</p>
             <p class="footer__links">
+                <a href="#upload-area" data-switch-target="workflow" data-scroll-target="upload-area">Generatore annuncio</a>
+                <span aria-hidden="true">·</span>
+                <a href="#view-switcher" data-switch-target="ecommerce" data-scroll-target="ecommerce-intro">Vai all'e-commerce</a>
+                <span aria-hidden="true">·</span>
                 <a href="documentation/SoftwareArchitecture.md">Documentazione</a>
-                <span aria-hidden="true">·</span>
-                <a href="#upload-area">Torna al form</a>
-                <span aria-hidden="true">·</span>
-                <a href="ecommerce.html">Vai all'e-commerce</a>
             </p>
         </div>
     </footer>
 
+    <script src="assets/js/store.js"></script>
     <script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce a two-button view switcher on the landing page so users can toggle between the announcement workflow and an improved e-commerce showcase with richer mock product cards
- refresh styling to support the new toggle, illustrated cards, and filter controls while keeping mobile responsiveness intact
- extend the JavaScript to manage view selection, reset catalogue filters, redirect the legacy ecommerce page, and document placeholder images to be populated later

## Testing
- Not run (static site mockup)


------
https://chatgpt.com/codex/tasks/task_e_68e58ed13dc4832aadd287d0d5ef1376