### PR TITLE
Remove arrow icon from ecommerce view switcher

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -205,8 +205,6 @@ img {
     align-items: flex-start;
     justify-content: space-between;
     padding: 32px;
-    padding-right: 56px;
-    padding-bottom: 56px;
     border-radius: var(--radius-large);
     border: 1px solid rgba(28, 77, 216, 0.12);
     background: linear-gradient(135deg, rgba(47, 139, 253, 0.08), rgba(0, 198, 174, 0.08));
@@ -225,14 +223,6 @@ img {
 .view-switcher__button .view-switcher__subtitle {
     font-weight: 400;
     color: var(--color-muted);
-}
-
-.view-switcher__icon {
-    position: absolute;
-    bottom: 24px;
-    right: 24px;
-    font-size: 1.5rem;
-    color: var(--color-primary-dark);
 }
 
 .view-switcher__button:hover,

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,6 @@
                 <button type="button" class="view-switcher__button" data-switch-target="ecommerce" data-scroll-target="ecommerce-intro">
                     <span class="view-switcher__label">Vetrina e-commerce</span>
                     <span class="view-switcher__subtitle">Catalogo con categorie, filtri e schede illustrate.</span>
-                    <span class="view-switcher__icon" aria-hidden="true">↗</span>
                 </button>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- remove the decorative arrow icon from the ecommerce view switcher button
- simplify the button padding now that no corner icon is displayed

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5952933fc832ab07acd0815344106